### PR TITLE
Don't raise exception when adapter can't be retrieved

### DIFF
--- a/src/main/kotlin/com/hypercubetools/hamkrest/moshi/MoshiMatcher.kt
+++ b/src/main/kotlin/com/hypercubetools/hamkrest/moshi/MoshiMatcher.kt
@@ -9,17 +9,26 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
 import java.io.IOException
 
+internal const val UNKNOWN_TYPE_NAME = "unknown type"
+internal const val ARRAY_UNKNOWN_TYPE_NAME = "array of $UNKNOWN_TYPE_NAME"
+
 inline fun <reified T> deserializesTo(value: T, moshi: Moshi = Moshi.Builder().build()): Matcher<String?> = deserializesTo(equalTo(value), moshi)
 
 inline fun <reified T> deserializesTo(match: Matcher<T>? = null, moshi: Moshi = Moshi.Builder().build()): Matcher<String?> =
-        JsonDeserializeMatcher(T::class.simpleName, moshi.adapter(T::class.java).failOnUnknown(), match)
+        JsonDeserializeMatcher(T::class.java, moshi, match)
 
 // Implemented outside of inline function so test coverage is reported correctly
 // https://github.com/jacoco/jacoco/issues/654
-class JsonDeserializeMatcher<T>(private val className: String?, private val adapter: JsonAdapter<T>, private val match: Matcher<T>?) : Matcher<String?> {
+class JsonDeserializeMatcher<T>(private val targetClass: Class<T>, private val moshi: Moshi, private val match: Matcher<T>?) : Matcher<String?> {
     override fun invoke(actual: String?): MatchResult {
         if (actual == null) {
             return MatchResult.Mismatch("actual was null")
+        }
+        val adapter: JsonAdapter<T>
+        try {
+            adapter = moshi.adapter(targetClass).failOnUnknown()
+        } catch (ex: IllegalArgumentException) {
+            return MatchResult.Mismatch("Moshi adapter could not be created: $ex")
         }
         return try {
             val deserialized = adapter.fromJson(actual) ?: return MatchResult.Mismatch("deserialized result was null")
@@ -38,6 +47,15 @@ class JsonDeserializeMatcher<T>(private val className: String?, private val adap
         }
     }
 
-    override val description get() = "deserializes to ${if (match == null) className ?: "unknown type" else describe(match)}"
+    override val description get() = "deserializes to ${if (match == null) targetName else describe(match)}"
     override val negatedDescription: String get() = "is not $description"
+    private val targetName = tweakClassSimpleName(targetClass.simpleName)
+}
+
+// Details on what simpleName can return
+// https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/lang/Class.html#getSimpleName()
+internal fun tweakClassSimpleName(name: String) = when(name) {
+    "" -> UNKNOWN_TYPE_NAME
+    "[]" -> ARRAY_UNKNOWN_TYPE_NAME
+    else -> name
 }

--- a/src/test/java/com/hypercubetools/hamkrest/moshi/Container.java
+++ b/src/test/java/com/hypercubetools/hamkrest/moshi/Container.java
@@ -1,0 +1,10 @@
+package com.hypercubetools.hamkrest.moshi;
+
+// An anonymous classes are needed to check output of Class::getSimpleName()
+public class Container {
+    @SuppressWarnings("Convert2Lambda")
+    public static Runnable anonymousInstance = new Runnable() {
+        @Override
+        public void run() {}
+    };
+}


### PR DESCRIPTION
Move adapter retrieval into invoke call. This changes an attempts to convert to an unsupported typed from an exception to a mismatch.