### PR TITLE
Bump version: 0.1.0 → 0.2.0 (take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2020-08-01
 
 * Initial Release
+


### PR DESCRIPTION
Second MR because CI publish job needed fixes (#25)